### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,24 @@
 [![License](https://img.shields.io/npm/l/nanomerge.svg)](https://github.com/nikolay-govorov/nanomerge/blob/master/LICENSE)
 [![GitHub package version](https://img.shields.io/github/package-json/v/nikolay-govorov/nanomerge.svg)](https://github.com/nikolay-govorov/nanomerge)
 
-Tiny universal isomorphic library for intellectual deep merging objects
+Tiny universal/isomorphic library for intelligently deep-merging objects
 
 ```js
 var nanomerge = require('nanomerge');
 
 var merger = nanomerge({
- strategy: { array: 'merge' }
+  strategy: { array: 'merge' }
 });
 
-//=> { a: [{ a: 1 }, { a: 3 }], b: 'It`s work!' }
-merger({ a: [{ a: 2 }, { a: 3 }] }, { a: [{ a: 1 }] }, { b: 'It`s work!' });
+//=> { a: [{ a: 1 }, { a: 3 }], b: 'It works!' }
+merger({ a: [{ a: 2 }, { a: 3 }] }, { a: [{ a: 1 }] }, { b: 'It works!' });
 ```
 
-* **Small**. Only 800 bytes (minified and gzipped). Only 'nano' dependencies. It uses Size Limit to control size.
+* **Small**. Only 800 bytes (minified and gzipped). Only "nano" dependencies. It uses [Size Limit](https://www.npmjs.com/package/size-limit) to keep the size under control.
 
-* **Easy**. Everything is working. Just plug and play.
+* **Easy**. Everything works out of the box. Just plug and play.
 
-* **Customizability**. But if you need to, everything can be customized
+* **Customizability**. But, if you need to, everything can be customized.
 
 The lib supports Node.js and all browsers starting from IE 11.
 
@@ -43,7 +43,7 @@ nanomerge({ a: 1, b: 2 }, { a: 2, c: 3 }, { b: 5, d: 7 }); //=> { a: 2, b: 5, c:
 
 #### Custom configuration
 
-If passed only one parameter, it is considered a configuration file. Will be created a customized instance.
+If passed only one parameter, it is interpreted as configuration data, and a customized merge function is returned.
 
 ```js
 var merge = nanomerge({ /* options */ });
@@ -56,10 +56,12 @@ merge({ a: 1 }, { b: 2 }) //=> { a: 1, b: 2 }
 ```js
 var config = {
   /**
-   * The strategy shows how we should handle a particular type
+   * The strategy specifies how we should handle a particular type
    */
   strategy: {
-    array: 'replace' // string: merge | replace | concat
+    array:     'replace', // string: merge | replace | concat
+    object:    'deep',    // string: deep
+    primitive: 'default', // string: default
   }
 };
 ```


### PR DESCRIPTION
\+ document the `object` and `primitive` strategy options.